### PR TITLE
Fix Batch extension method

### DIFF
--- a/src/Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/Extensions/IAsyncEnumerableExtensions.cs
@@ -907,7 +907,7 @@ namespace System.Collections.Async
             if (addItem == null)
                 throw new ArgumentNullException(nameof(addItem), "You must specify an action that adds an item to a batch.");
 
-            if (maxItemsInBatch == null || weightSelector == null)
+            if (maxItemsInBatch == null && weightSelector == null)
                 throw new InvalidOperationException("You must supply either a max batch size or a weight selector.");
 
             return new AsyncEnumerableWithState<TBatch, BatchContext<TSource, TBatch>>(

--- a/src/Extensions/IAsyncEnumerableExtensions.cs
+++ b/src/Extensions/IAsyncEnumerableExtensions.cs
@@ -1083,6 +1083,7 @@ namespace System.Collections.Async
 
                         context.AddItemToBatch(batch, enumerator.Current);
                         batchWeight += itemWeight;
+                        itemsInBatch += 1;
 
                         if (itemsInBatch >= context.MaxItemsInBatch || batchWeight >= context.MaxBatchWeight)
                         {


### PR DESCRIPTION
Fixes issue where you can't use the .Batch(int batchSize) extension method because it fails (faulty) input validation.